### PR TITLE
update install directions with wasm-pack

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,13 @@ Experimental rust-yt work to compile to wasm.
 
 To get this working, you will need to install [rustup](https://rustup.rs/) and
 potentially set it to use the nightly installation.
+
+The easiest way to build this package is to install the crate wasm-pack. Once
+you've done that, you should be able to build from source using the following
+steps:
+
+```
+git clone https://github.com/data-exp-lab/rust-yt-tools
+cd ./rust-yt-tools
+wasm-pack init --scope data-exp-lab
+```


### PR DESCRIPTION
This is just a starting point, but I think we should make it clear how to install from source with wasm-pack, since this is the process we've been using to build this package for a while now. The scope flag that we use isn't necessarily intuitive if somebody wants to build the rust/wasm and the widget from source. 