### PR TITLE
Allow multiple fields for variable mesh objects

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yt-tools"
-version = "0.3.2"
+version = "0.4.0"
 authors = ["Matthew Turk <matthewturk@gmail.com>",
            "Madicken Munk <madicken.munk@gmail.com>"]
 description = "Experiments with porting yt components to Rust"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ crate-type = ["cdylib", "rlib"]
 default = ["console_error_panic_hook"]
 
 [dependencies]
-wasm-bindgen = "0.2"
+wasm-bindgen = "0.2.71"
 
 # The `console_error_panic_hook` crate provides better debugging of panics by
 # logging them with `console.error`. This is great for development, but requires

--- a/src/fixed_resolution_buffer.rs
+++ b/src/fixed_resolution_buffer.rs
@@ -40,7 +40,7 @@ impl FixedResolutionBuffer {
         }
     }
 
-    pub fn deposit(&mut self, vmesh: &VariableMesh, buffer: &mut [f64]) -> u32 {
+    pub fn deposit(&mut self, vmesh: &VariableMesh, buffer: &mut [f64], name: String) -> u32 {
         let mut count: u32 = 0;
 
         // We do need to clear the buffer -- in cases where the buffer is completely filled this
@@ -52,7 +52,7 @@ impl FixedResolutionBuffer {
         let mut image_buffer: Vec<&mut [f64]> =
             buffer.chunks_exact_mut(self.height).rev().collect();
 
-        for pixel in vmesh.iter() {
+        for pixel in vmesh.iter(&name) {
             // Compute our left edge pixel
             if pixel.px + pixel.pdx < self.x_low
                 || pixel.py + pixel.pdy < self.y_low

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,8 @@ mod tests {
         let mut py: Vec<f64> = Vec::new();
         let mut pdx: Vec<f64> = Vec::new();
         let mut pdy: Vec<f64> = Vec::new();
-        let mut field: Vec<f64> = Vec::new();
+        let mut field1: Vec<f64> = Vec::new();
+        let mut field2: Vec<f64> = Vec::new();
 
         let _nval = 32;
         let _npix = 1024;
@@ -67,7 +68,8 @@ mod tests {
                 py.push(y);
                 pdx.push(_pdx);
                 pdy.push(_pdy);
-                field.push(1.0);
+                field1.push(1.0);
+                field2.push(2.13);
                 y += _pdy;
             }
             assert_eq!(y, 1.0);
@@ -76,10 +78,15 @@ mod tests {
 
         assert_eq!(x, 1.0);
 
-        let _vm = VariableMesh::new(px, py, pdx, pdy, field);
+        let mut _vm = VariableMesh::new(px, py, pdx, pdy);
+        _vm.add_field("default", field1);
+        _vm.add_field("alternate", field2);
 
-        for pixel in _vm.iter() {
+        for pixel in _vm.iter("default") {
             assert_eq!(pixel.val, 1.0);
+        }
+        for pixel in _vm.iter("alternate") {
+            assert_eq!(pixel.val, 2.13);
         }
 
         let mut _frb_test = FixedResolutionBuffer::new(_npix, _npix, 0.0, 1.0, 0.0, 1.0);
@@ -89,10 +96,16 @@ mod tests {
 
         // This does not always work, because of how we compute rows and columns,
         // so we don't assert.  We will eventually do so, though.
-        let _count = _frb_test.deposit(&_vm, buffer.as_mut_slice());
+        let _count = _frb_test.deposit(&_vm, buffer.as_mut_slice(), "default".to_string());
 
         for &v in buffer.iter() {
             assert_eq!(v, 1.0);
+        }
+
+        let _count = _frb_test.deposit(&_vm, buffer.as_mut_slice(), "alternate".to_string());
+
+        for &v in buffer.iter() {
+            assert_eq!(v, 2.13);
         }
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,5 +1,6 @@
 use wasm_bindgen::prelude::*;
 
+#[allow(dead_code)]
 #[wasm_bindgen(start)]
 pub fn set_panic_hook() {
     // When the `console_error_panic_hook` feature is enabled, we can call the

--- a/src/variable_mesh.rs
+++ b/src/variable_mesh.rs
@@ -45,7 +45,7 @@ impl VariableMesh {
         }
         let mut field_values = HashMap::new();
         let mut default_values: Vec<f64> = Vec::new();
-        for i in 0..size {
+        for _i in 0..size {
             default_values.push(1.0);
         }
         field_values.insert(String::from("ones"), default_values);
@@ -133,7 +133,7 @@ mod tests {
             pdy.push((i as f64) * 0.22);
             val.push((i as f64) * 4.05);
         }
-        let vm = VariableMesh::new(px, py, pdx, pdy);
+        let mut vm = VariableMesh::new(px, py, pdx, pdy);
         vm.add_field("default", val);
         for (i, pixel) in vm.iter("default").enumerate() {
             assert_eq!(pixel.px, (i as f64) * 1.0);
@@ -143,5 +143,13 @@ mod tests {
             assert_eq!(pixel.val, (i as f64) * 4.05);
         }
         assert_eq!(vm.iter("default").count(), 1024 * 1024);
+        for (i, pixel) in vm.iter("ones").enumerate() {
+            assert_eq!(pixel.px, (i as f64) * 1.0);
+            assert_eq!(pixel.py, (i as f64) * 1.2);
+            assert_eq!(pixel.pdx, (i as f64) * 0.21);
+            assert_eq!(pixel.pdy, (i as f64) * 0.22);
+            assert_eq!(pixel.val, 1.0);
+        }
+        assert_eq!(vm.iter("ones").count(), 1024 * 1024);
     }
 }

--- a/src/variable_mesh.rs
+++ b/src/variable_mesh.rs
@@ -60,7 +60,7 @@ impl VariableMesh {
     pub fn add_field(&mut self, name: &str, field_values: Vec<f64>) {
         self.field_values.insert(String::from(name), field_values);
     }
-    pub fn has_field(self, name: &str) -> bool {
+    pub fn has_field(&self, name: &str) -> bool {
         self.field_values.contains_key(name)
     }
 }

--- a/src/variable_mesh.rs
+++ b/src/variable_mesh.rs
@@ -60,6 +60,9 @@ impl VariableMesh {
     pub fn add_field(&mut self, name: &str, field_values: Vec<f64>) {
         self.field_values.insert(String::from(name), field_values);
     }
+    pub fn has_field(self, name: &str) -> bool {
+        self.field_values.contains_key(name)
+    }
 }
 
 impl VariableMesh {


### PR DESCRIPTION
This starts the process of tracking multiple fields, and making them accessible by the iteration and deposition.  widgyts has not been updated yet.
